### PR TITLE
fix: No sublinks menu if mouse leaves window first

### DIFF
--- a/afros-sublinks.user.js
+++ b/afros-sublinks.user.js
@@ -8,7 +8,7 @@
 // @exclude     https://*/release/add
 // @exclude     https://musicbrainz.*/oauth2/authorize*
 // @grant       none
-// @version     0.7
+// @version     0.7.1
 // @author      afro
 // @description Mouse over a MB entity link and press shift to open a menu with useful shortcuts
 // @require     https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js
@@ -188,7 +188,7 @@ document.addEventListener('mousemove', (e) => {
 });
 
 document.addEventListener('mouseleave', (e) => {
-  if (e.target.closest('a') === hoveredObject) {
+  if (e.target.parentNode !== null && e.target.closest('a') === hoveredObject) {
     hoveredObject = null;
   }
 });


### PR DESCRIPTION
When your mouse leaved the window,
e.target is "document" above topmost <html> tag.
Then onmouseleave event triggered error:
Uncaught TypeError: e.target.closest is not a function

If this mouseleave error happened
before sublinks menu ever displayed,
then sublinks menu would never be displayed.